### PR TITLE
Add python script to generate mapgrouppos entries from json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@ A simple spreadsheet that allows the easy conversion of the Y YAW or rotation va
 
 FILES MUST BE DOWNLOADED TO LOCAL PC TO BE USED! CLICK ON GREEN "CODE" BUTTON!
 OPEN IN YOUR PREFFERED SPREADHEET PROGRAMME!
+
+To use the python scrript you must download and install python3 https://www.python.org/downloads/
+
+Run the script from command line (Windows+R, "cmd", enter)
+
+Command to run the script:` python3 ./json2mapgrouppos.py C:/path/to/json/file.json
+`

--- a/json2mapgrouppos.py
+++ b/json2mapgrouppos.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# python script written by t0y shop for Scalespeeder
+# maths supplied by Scalespeeder
+import json
+import sys
+from os.path import exists
+
+if len(sys.argv) != 2:
+    print ("You must provide a valid file path")
+    exit(1)
+
+filepath = sys.argv.pop()
+
+if (exists(filepath) == False):
+    print(f"file {filepath} does not exist")
+    exit(1) 
+
+def convert_y_to_a(yaw):
+    if yaw < -90:
+        return (-180 - yaw) - 90
+    elif yaw < 0:
+        return (180 - yaw) - 90
+    else:
+        return (360 - yaw) - 270
+
+f = open(filepath)
+try:
+    data = json.load(f)
+    for object in data['Objects']:
+
+        outputString = f"<group name=\"{object['name']}\" pos=\"{object['pos'][0]} {object['pos'][1]} {object['pos'][2]}\""
+        outputString += f" rpy=\"{object['ypr'][2]} {object['ypr'][1]} {object['ypr'][0]}\"" 
+        outputString += f" a=\"{convert_y_to_a(object['ypr'][0])}\" />"
+        print(outputString)
+except:
+    print ("Could not parse the supplied file")


### PR DESCRIPTION
Hey,

With this you can pass in a json file like

```json
{
    "Objects": [
        {
            "name": "Land_Mil_ControlTower",
            "pos": [
                4674.869140625,
                346.6190185546875,
                10336.775390625
            ],
            "ypr": [
                -27.0,
                0.0,
                0.0
            ]
        },
        {
            "name": "Land_Medical_Tent_Big",
            "pos": [
                4672.33154296875,
                339.0177307128906,
                10384.736328125
            ],
            "ypr": [
                -116.99991607666016,
                0.0,
                -0.0
            ]
        }
    ]
 }
        
```
        
  and get output like,
        
```xml
<group name="Land_Mil_ControlTower" pos="4674.869140625 346.6190185546875 10336.775390625" rpy="0.0 0.0 -27.0" a="117.0" />
<group name="Land_Medical_Tent_Big" pos="4672.33154296875 339.0177307128906 10384.736328125" rpy="-0.0 0.0 -116.99991607666016" a="-153.00008392333984" />
```

usage: `python3 ./json2mapgrouppos.py C:/path/to/json/file.json` 

you need to install python3 for it to work https://www.python.org/downloads/ 